### PR TITLE
react sort state

### DIFF
--- a/frontend/_base.js
+++ b/frontend/_base.js
@@ -42,6 +42,7 @@ module.exports = {
         'mixins',
         'statics',
         'defaultProps',
+        'state',
         'constructor',
         'getDefaultProps',
         'getInitialState',


### PR DESCRIPTION
Currently lint requires `state` to be list AFTER `render`.  This moves it above the constructor.