### PR TITLE
react sort everything-else

### DIFF
--- a/frontend/_base.js
+++ b/frontend/_base.js
@@ -56,6 +56,7 @@ module.exports = {
         'componentWillUnmount',
         '/^(on|handle).+$/',
         '/^get.+$/',
+        'everything-else',
         '/^render.+$/',
         'render',
       ],


### PR DESCRIPTION
Puts `everything-else` just above render and after all other specified orderings.