### PR TITLE
fix(base config): override airbnb react/prefer-stateless-function rule to be warning

### DIFF
--- a/frontend/_base.js
+++ b/frontend/_base.js
@@ -77,6 +77,7 @@ module.exports = {
      */
     // Prevent function creation on each render
     'react/jsx-no-bind': 1, // intended: 2
+    'react/prefer-stateless-function': 1, // intended: 2
 
     /**
      * Style


### PR DESCRIPTION
Resolve `error` linter coming from Airbnb defaults Re stateless components.

![image](https://cloud.githubusercontent.com/assets/5421430/13577526/79136288-e458-11e5-8c66-530189f63e5b.png)
