### PR TITLE
No prefer-template

### DIFF
--- a/organization/_base.js
+++ b/organization/_base.js
@@ -114,6 +114,6 @@ module.exports = {
     'arrow-body-style': [0, 'as-needed'],
     'consistent-return': 2,
     'no-param-reassign': 0, // overrides airbnb rule
-    'prefer-template': 2,
+    'prefer-template': 0,
   },
 }


### PR DESCRIPTION
Allow string concatenation.  It looks like no organization enforces this anyhow, we had it turned on only:

![image](https://cloud.githubusercontent.com/assets/5067638/16535828/837be8f6-3f9f-11e6-98e3-9218e8b2aafb.png)
